### PR TITLE
Add `:RuboCopAutoCorrect` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ You can use the `:RuboCop` command to run RuboCop and display the results.
 
 You can also use the `:RuboCop` command together with options. For example, `:RuboCop -l`, `:RuboCop -a` and so on.
 
+You can use the `:RuboCopAutoCorrect` command to write out your buffer,
+run `rubocop -a` on the file and re-open it in your buffer.  This will
+prevent the results window from opening.
+
 ### Configuration File
 
 To run with the specified configuration file, add the following line to your `.vimrc` file:
@@ -40,8 +44,12 @@ In the quickfix window, you can use:
     gv   to open in vertical split silently
     q    to close the quickfix window
 
-Additionally, the plugin registers `<Leader>ru` in normal mode
-for triggering it easily. You can disable these default mappings by setting
+Additionally, the plugin registers:
+
+* `<Leader>ru` in normal mode for triggering `:RuboCop`
+* `<Leader>ra` in normal mode for triggering `:RuboCopAutoCorrect`
+
+You can disable these default mappings by setting
 `g:vimrubocop_keymap` in your `.vimrc` file, and then remap them differently.
 
 For instance, to trigger RuboCop by pressing `<Leader>r` you can put the following in
@@ -50,6 +58,7 @@ your `.vimrc`:
 ```viml
 let g:vimrubocop_keymap = 0
 nmap <Leader>r :RuboCop<CR>
+nmap <Leader>a :RuboCopAutoCorrect<CR>
 ```
 
 ## License

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -32,6 +32,10 @@ if !exists('g:vimrubocop_keymap')
   let g:vimrubocop_keymap = 1
 endif
 
+if !exists('g:vimrubocop_should_copen')
+  let g:vimrubocop_should_copen = 1
+endif
+
 let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct']
 
 function! s:RuboCopSwitches(...)
@@ -54,25 +58,44 @@ function! s:RuboCop(current_args)
   endif
   let l:rubocop_output  = substitute(l:rubocop_output, '\\"', "'", 'g')
   let l:rubocop_results = split(l:rubocop_output, "\n")
-  cexpr l:rubocop_results
-  copen
-  " Shortcuts taken from Ack.vim - git://github.com/mileszs/ack.vim.git
-  exec "nnoremap <silent> <buffer> q :ccl<CR>"
-  exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
-  exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
-  exec "nnoremap <silent> <buffer> o <CR>"
-  exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
-  exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
-  exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
-  exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
-  exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+
+  if g:vimrubocop_should_copen == 1
+    cexpr l:rubocop_results
+    copen
+    " Shortcuts taken from Ack.vim - git://github.com/mileszs/ack.vim.git
+    exec "nnoremap <silent> <buffer> q :ccl<CR>"
+    exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
+    exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
+    exec "nnoremap <silent> <buffer> o <CR>"
+    exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
+    exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
+    exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
+    exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
+    exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+  endif
+endfunction
+
+function s:RuboCopQuiet(current_args)
+  let l:vimrubocop_should_copen_save = g:vimrubocop_should_copen
+  let g:vimrubocop_should_copen = 0
+
+  call s:RuboCop(a:current_args)
+
+  let g:vimrubocop_should_copen = l:vimrubocop_should_copen_save
+endfunction
+
+function s:RuboCopAutoCorrect()
+  write
+  call s:RuboCopQuiet("-a")
 endfunction
 
 command! -complete=custom,s:RuboCopSwitches -nargs=? RuboCop :call <SID>RuboCop(<q-args>)
+command! -nargs=0 RuboCopAutoCorrect :call <SID>RuboCopAutoCorrect()
 
 " Shortcuts for RuboCop
 if g:vimrubocop_keymap == 1
   nmap <Leader>ru :RuboCop<CR>
+  nmap <Leader>ra :RuboCopAutoCorrect<CR>
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
- update README
- new var `g:vimrubocop_should_copen` to determine whether `s:RuboCop`
  should copen a new split
- new function `s:RuboCopQuiet` to wrap `s:RuboCop` so that it does not
  copen a new split
- new function `s:RuboCopAutoCorrect`, mapped to `:RuboCopAutoCorrect`
  and default shortcut `<leader>ra`
